### PR TITLE
feat: Allow removing files from Git

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ jobs:
           repository: ${{ github.repository }}
           ref: refs/heads/branch-name
           path: glob-pattern
+          remove: files to remove from Git
           message: your-commit-message
 ```
 

--- a/action.yaml
+++ b/action.yaml
@@ -11,6 +11,9 @@ inputs:
   path:
     description: glob paths to commit
     required: true
+  remove:
+    description: list of paths to remove
+    required: false
   base-directory:
     description: base directory to compute a path of file to commit
     required: true

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ const main = async (): Promise<void> => {
     repository: core.getInput('repository', { required: true }),
     ref: core.getInput('ref', { required: true }),
     path: core.getInput('path', { required: true }),
+    remove: core.getMultilineInput('remove', { required: false }),
     baseDirectory: core.getInput('base-directory', { required: true }),
     message: core.getInput('message', { required: true }),
     token: core.getInput('token', { required: true }),

--- a/src/run.ts
+++ b/src/run.ts
@@ -8,6 +8,7 @@ type Inputs = {
   repository: string
   ref: string
   path: string
+  remove: string[]
   baseDirectory: string
   message: string
   token: string
@@ -35,6 +36,18 @@ export const run = async (inputs: Inputs): Promise<void> => {
       }
     }),
   )
+
+  if (inputs.remove) {
+    for (const f of inputs.remove) {
+      core.info(`removing ${f}`)
+      treeEntries.push({
+        path: f,
+        mode: "100644",
+        type: "blob",
+        sha: '',
+      });
+    }
+  }
 
   await pushWithRetry(octokit, {
     owner,


### PR DESCRIPTION
Currently, when this action creates a commit it can only add new or modify existing files under Git version control. 
This PR provides a way to specify list of files that should be deleted.

For example, the following should remove files `go.mod` and `go.sum` from Git:

```
...
path: |
  ...
remove: |
  go.mod
  go.sum
message: ...
token: ...
```

The implementation is pretty basic: for each file that needs to be removed a tree entry with empty `sha` is added (which effectively removes the blob from Git).